### PR TITLE
Consistent path notation in DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,6 +36,6 @@ Este documento define as diretrizes visuais e de componentes para o sistema Bibl
 - **Estado de Carga:** `Skeleton` com animação suave de pulsação.
 
 ## 4. Estrutura de Pastas
-- `src/components/ui/` -> Componentes primitivos (Radix + Tailwind).
-- `src/components/shared/` -> Componentes compostos (Layouts, Navbar).
+- `frontend/src/components/ui/` -> Componentes primitivos (Radix + Tailwind).
+- `frontend/src/components/shared/` -> Componentes compostos (Layouts, Navbar).
 - Estrutura de Rotas -> Crie páginas como pastas de rota contendo um arquivo `page.tsx` (ex: `frontend/src/home/page.tsx` e `frontend/src/login/page.tsx`).


### PR DESCRIPTION
Updated Section 4 of DESIGN.md to use consistent path-root notation. Changed `src/components/ui/` to `frontend/src/components/ui/` and `src/components/shared/` to `frontend/src/components/shared/` to match the existing `frontend/src/home/page.tsx` examples. This ensures a uniform convention throughout the section. Verified the changes by reading the file and confirmed no regressions by running frontend tests.

---
*PR created automatically by Jules for task [5434702547881330395](https://jules.google.com/task/5434702547881330395) started by @tetri*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated component directory structure references in design guidelines to reflect the current folder organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->