### PR TITLE
Fix Timeouts and Observability Consistency

### DIFF
--- a/frontend/src/admin/page.tsx
+++ b/frontend/src/admin/page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -8,6 +8,15 @@ import { ErrorMessage } from '../components/error-message';
 export default function AdminPage() {
   const navigate = useNavigate();
   const [notice, setNotice] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleLogout = () => {
     localStorage.removeItem('token');
@@ -15,8 +24,14 @@ export default function AdminPage() {
   };
 
   const handlePlaceholderClick = (feature: string) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
     setNotice(`${feature} será implementado em breve.`);
-    setTimeout(() => setNotice(null), 5000);
+    timeoutRef.current = setTimeout(() => {
+      setNotice(null);
+      timeoutRef.current = null;
+    }, 5000);
   };
 
   return (

--- a/frontend/src/catalog/page.tsx
+++ b/frontend/src/catalog/page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../lib/api';
 import { decodeJwtPayload } from '../lib/utils';
@@ -24,6 +24,15 @@ export function BooksPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingBookIds, setPendingBookIds] = useState<Set<string>>(new Set());
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const errorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current);
+      if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
+    };
+  }, []);
 
   const { data: books, isLoading, error } = useQuery({
     queryKey: ['books'],
@@ -50,18 +59,26 @@ export function BooksPage() {
         setPendingBookIds(prev => new Set(prev).add(bookId));
     },
     onSuccess: () => {
+        if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current);
         setSuccessMessage("Livro reservado com sucesso!");
         queryClient.invalidateQueries({ queryKey: ['books'] });
-        setTimeout(() => setSuccessMessage(null), 5000);
+        successTimeoutRef.current = setTimeout(() => {
+            setSuccessMessage(null);
+            successTimeoutRef.current = null;
+        }, 5000);
     },
     onError: (err: any) => {
+        if (errorTimeoutRef.current) clearTimeout(errorTimeoutRef.current);
         const errorData = err.response?.data;
         const message = typeof errorData === 'string'
             ? errorData
             : (errorData?.message || err.message || "Erro ao reservar livro.");
 
         setErrorMessage(message);
-        setTimeout(() => setErrorMessage(null), 5000);
+        errorTimeoutRef.current = setTimeout(() => {
+            setErrorMessage(null);
+            errorTimeoutRef.current = null;
+        }, 5000);
     },
     onSettled: (_, __, bookId) => {
         setPendingBookIds(prev => {

--- a/shared/Shared.Observability/OpenTelemetryExtensions.cs
+++ b/shared/Shared.Observability/OpenTelemetryExtensions.cs
@@ -22,6 +22,7 @@ public static class OpenTelemetryExtensions
             .WithMetrics(metricsProviderBuilder =>
             {
                 metricsProviderBuilder
+                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName))
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
                     .AddConsoleExporter();

--- a/shared/Shared.Observability/Shared.Observability.csproj
+++ b/shared/Shared.Observability/Shared.Observability.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR addresses several frontend and backend issues:
1. **Frontend Timeout Race Conditions**: In `frontend/src/admin/page.tsx` and `frontend/src/catalog/page.tsx`, timeouts were being set without clearing previous ones, leading to UI messages disappearing prematurely if multiple actions were performed quickly. These are now managed using `useRef` to store and clear timeout IDs, with additional cleanup in `useEffect`.
2. **Observability Consistency**: The OpenTelemetry metrics pipeline in `shared/Shared.Observability/OpenTelemetryExtensions.cs` was missing service attribution. I've added `SetResourceBuilder` to match the tracing configuration.
3. **Package Version Harmony**: Updated OpenTelemetry package references in `shared/Shared.Observability/Shared.Observability.csproj` to a consistent version (`1.12.0`) to avoid dependency conflicts and `NU1605` downgrade errors.
4. **Code Cleanup**: Verified that the unused `AlertCircle` import mentioned in the findings was already absent from `frontend/src/catalog/page.tsx`.

---
*PR created automatically by Jules for task [7719657196225698276](https://jules.google.com/task/7719657196225698276) started by @tetri*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed notice and toast message timer handling to ensure proper cleanup during component lifecycle.

* **Chores**
  - Updated OpenTelemetry dependencies to version 1.12.0 for improved observability performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->