### PR TITLE
Fix Reservation Guards and Profile State Sync

### DIFF
--- a/frontend/src/catalog/page.tsx
+++ b/frontend/src/catalog/page.tsx
@@ -102,8 +102,8 @@ export function BooksPage() {
     onMutate: (bookId: string) => {
         setPendingBookIds(prev => new Set(prev).add(bookId));
     },
-    onSuccess: (_, bookId) => {
-        queryClient.invalidateQueries({ queryKey: ['books'] });
+    onSuccess: async (_, bookId) => {
+        await queryClient.invalidateQueries({ queryKey: ['books'] });
         setPendingBookIds(prev => {
             const next = new Set(prev);
             next.delete(bookId);

--- a/frontend/src/perfil/page.tsx
+++ b/frontend/src/perfil/page.tsx
@@ -93,11 +93,11 @@ export default function ProfilePage() {
     mutationFn: async () => {
       return api.put('/user/api/users/me', { name, password: password || undefined });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       scheduleClearMessage(setSuccessMessage, "Perfil atualizado com sucesso!");
       setPassword('');
+      await queryClient.invalidateQueries({ queryKey: ['profile'] });
       setIsNameDirty(false);
-      queryClient.invalidateQueries({ queryKey: ['profile'] });
     },
     onError: (err: any) => {
       const errorData = err.response?.data;

--- a/services/loan-service/LoanService.Api/Program.cs
+++ b/services/loan-service/LoanService.Api/Program.cs
@@ -57,6 +57,12 @@ builder.Services
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var mongoContext = scope.ServiceProvider.GetRequiredService<MongoContext>();
+    await mongoContext.ConfigureIndexesAsync();
+}
+
 app.MapOpenApi();
 app.MapScalarApiReference(options => {
     options.WithTitle("Biblioteca API - LoanService");

--- a/services/loan-service/LoanService.Domain/Entities/Loan.cs
+++ b/services/loan-service/LoanService.Domain/Entities/Loan.cs
@@ -30,6 +30,9 @@ public class Loan
         if (existingLoans.Any(l => l.Status == LoanStatus.Overdue))
             return Result<Loan>.Failure("Usuário possui empréstimos em atraso.");
 
+        if (existingLoans.Any(l => l.BookId == bookId && (l.Status == LoanStatus.Reserved || l.Status == LoanStatus.Active)))
+            return Result<Loan>.Failure("Usuário já possui uma reserva ou empréstimo ativo para este livro.");
+
         var loan = new Loan
         {
             UserId = userId,

--- a/services/loan-service/LoanService.Infrastructure/MongoContext.cs
+++ b/services/loan-service/LoanService.Infrastructure/MongoContext.cs
@@ -14,4 +14,20 @@ public class MongoContext
     }
 
     public IMongoCollection<Loan> Loans => _database.GetCollection<Loan>("loans");
+
+    public async Task ConfigureIndexesAsync()
+    {
+        var indexKeysDefinition = Builders<Loan>.IndexKeys
+            .Ascending(l => l.UserId)
+            .Ascending(l => l.BookId);
+
+        var indexOptions = new CreateIndexOptions<Loan>
+        {
+            Unique = true,
+            PartialFilterExpression = Builders<Loan>.Filter.In(l => l.Status, new[] { LoanStatus.Reserved, LoanStatus.Active })
+        };
+
+        var indexModel = new CreateIndexModel<Loan>(indexKeysDefinition, indexOptions);
+        await Loans.Indexes.CreateOneAsync(indexModel);
+    }
 }


### PR DESCRIPTION
This PR addresses several issues related to data integrity and UI consistency:

1. **Loan Idempotency**: The backend now prevents duplicate reservations or active loans for the same user and book. This is enforced both in the domain logic (`Loan.cs`) and at the database layer via a MongoDB unique partial index.
2. **Catalog UX**: The frontend catalog page now correctly handles the "pending" state of a reservation, ensuring the button remains disabled until the cache has been fully refreshed.
3. **Profile Sync**: Fixed a bug where updating the user profile could cause the name field to revert to stale data. The UI now waits for the 'profile' query to be invalidated and refetched before allowing the local state to sync from the cache.

Verification:
- Backend unit tests passed.
- Frontend Vitest tests passed.
- Playwright verification scripts confirmed correct UI behavior for both reservation and profile update flows.

---
*PR created automatically by Jules for task [4650219564750383370](https://jules.google.com/task/4650219564750383370) started by @tetri*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data synchronization timing issues in profile updates and book reservation flows where UI changes could occur before backend cache was properly refreshed.
  * Added validation to prevent users from creating duplicate reservations for the same book.
  * Enhanced database performance through optimized indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->