### PR TITLE
Add duplicate-guard logic to Loan.Reserve

### DIFF
--- a/services/loan-service/LoanService.Domain/Entities/Loan.cs
+++ b/services/loan-service/LoanService.Domain/Entities/Loan.cs
@@ -50,6 +50,9 @@ public class Loan
         if (existingLoans.Any(l => l.Status == LoanStatus.Overdue))
             return Result<Loan>.Failure("Usuário possui empréstimos em atraso.");
 
+        if (existingLoans.Any(l => l.BookId == bookId && (l.Status == LoanStatus.Reserved || l.Status == LoanStatus.Active)))
+            return Result<Loan>.Failure("Usuário já possui uma reserva ou empréstimo ativo para este livro.");
+
         var loan = new Loan
         {
             UserId = userId,

--- a/services/loan-service/LoanService.Tests/LoanReserveTests.cs
+++ b/services/loan-service/LoanService.Tests/LoanReserveTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using LoanService.Domain.Entities;
+
+namespace LoanService.Tests;
+
+public class LoanReserveTests
+{
+    [Fact]
+    public void Reserve_ShouldReturnFailure_WhenUserAlreadyHasActiveLoanForSameBook()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var bookId = Guid.NewGuid();
+        var activeLoan = Loan.Create(userId, bookId, new List<Loan>()).Value!;
+        var existingLoans = new List<Loan> { activeLoan };
+
+        // Act
+        var result = Loan.Reserve(userId, bookId, existingLoans);
+
+        // Assert
+        result.IsFailure.Should().BeTrue("User already has an active loan for this book");
+        result.Error.Should().Be("Usuário já possui uma reserva ou empréstimo ativo para este livro.");
+    }
+
+    [Fact]
+    public void Reserve_ShouldReturnFailure_WhenUserAlreadyHasReservedLoanForSameBook()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var bookId = Guid.NewGuid();
+        var reservedLoan = Loan.Reserve(userId, bookId, new List<Loan>()).Value!;
+        var existingLoans = new List<Loan> { reservedLoan };
+
+        // Act
+        var result = Loan.Reserve(userId, bookId, existingLoans);
+
+        // Assert
+        result.IsFailure.Should().BeTrue("User already has a reserved loan for this book");
+        result.Error.Should().Be("Usuário já possui uma reserva ou empréstimo ativo para este livro.");
+    }
+}


### PR DESCRIPTION
The `Reserve` method in the `Loan` entity was missing a duplicate-guard check that was present in the `Create` method. This allowed users to potentially create multiple reservations or a reservation for a book they already have an active loan for, until blocked by database constraints.

Changes:
- Modified `services/loan-service/LoanService.Domain/Entities/Loan.cs` to include a check for existing active or reserved loans for the same book/user in the `Reserve` static factory method.
- Created `services/loan-service/LoanService.Tests/LoanReserveTests.cs` with unit tests covering these scenarios.
- Verified that all tests in `LoanService.Tests` pass.

---
*PR created automatically by Jules for task [13897277243686177629](https://jules.google.com/task/13897277243686177629) started by @tetri*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loan reservation system now validates and prevents users from creating duplicate reservations for books they already have in active or reserved status.

* **Tests**
  * Added unit tests to verify that reservation creation properly fails when attempting to reserve a book with an existing active or reserved loan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->