### PR TITLE
Improve robustness of Loan unit test assertions

### DIFF
--- a/services/loan-service/LoanService.Tests/LoanReserveTests.cs
+++ b/services/loan-service/LoanService.Tests/LoanReserveTests.cs
@@ -11,7 +11,9 @@ public class LoanReserveTests
         // Arrange
         var userId = Guid.NewGuid();
         var bookId = Guid.NewGuid();
-        var activeLoan = Loan.Create(userId, bookId, new List<Loan>()).Value!;
+        var activeLoanResult = Loan.Create(userId, bookId, new List<Loan>());
+        activeLoanResult.IsSuccess.Should().BeTrue(activeLoanResult.Error);
+        var activeLoan = activeLoanResult.Value!;
         var existingLoans = new List<Loan> { activeLoan };
 
         // Act
@@ -28,7 +30,9 @@ public class LoanReserveTests
         // Arrange
         var userId = Guid.NewGuid();
         var bookId = Guid.NewGuid();
-        var reservedLoan = Loan.Reserve(userId, bookId, new List<Loan>()).Value!;
+        var reservedLoanResult = Loan.Reserve(userId, bookId, new List<Loan>());
+        reservedLoanResult.IsSuccess.Should().BeTrue(reservedLoanResult.Error);
+        var reservedLoan = reservedLoanResult.Value!;
         var existingLoans = new List<Loan> { reservedLoan };
 
         // Act

--- a/services/loan-service/LoanService.Tests/LoanServiceTests.cs
+++ b/services/loan-service/LoanService.Tests/LoanServiceTests.cs
@@ -35,7 +35,9 @@ public class LoanServiceTests
     {
         var userId = Guid.NewGuid();
         // Corrigindo a criação de Loan para o teste usando a factory
-        var existingLoan = Loan.Create(userId, Guid.NewGuid(), new List<Loan>()).Value!;
+        var existingLoanResult = Loan.Create(userId, Guid.NewGuid(), new List<Loan>());
+        existingLoanResult.IsSuccess.Should().BeTrue(existingLoanResult.Error);
+        var existingLoan = existingLoanResult.Value!;
         var existingLoans = Enumerable.Repeat(existingLoan, 3).ToList();
         _repositoryMock.Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLoans);
 


### PR DESCRIPTION
Replaced direct access to `.Value!` on `Loan.Create` and `Loan.Reserve` results with explicit success assertions in `LoanReserveTests.cs` and `LoanServiceTests.cs` to improve test failure clarity.

---
*PR created automatically by Jules for task [1538626182595429777](https://jules.google.com/task/1538626182595429777) started by @tetri*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by improving error handling verification in loan-related test suites. Tests now properly validate operation success before proceeding with assertions, reducing the risk of masked failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->